### PR TITLE
add nsticky in Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [niri-tag](https://git.atagen.co/atagen/niri-tag) - A single workspace, tag-based window management system for niri, featuring full IPC for shell integrations.
 - [niriswitcher](https://github.com/isaksamsten/niriswitcher) - An application switcher for niri, with support for workspaces and automatic dark mode.
 - [Nirius](https://sr.ht/~tsdh/nirius) - Utility commands for the niri.
+- [nsticky](https://github.com/lonerOrz/nsticky) - A utility to make windows visible across all workspaces in niri.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.
 
 ## Custom Shells


### PR DESCRIPTION
A utility to make windows visible across all workspaces in niri.