### PR TITLE
Add a "Bars and widgets" section separate from "Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [Official Resources](#official-resources)
 - [Packages](#packages)
 - [Tools](#tools)
+- [Bars and widgets](#bars-and-widgets)
 - [Custom Shells](#custom-shells)
 - [DE Integration](#de-integration)
 - [Distro Integration](#distro-integration)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [niri Flake](https://github.com/sodiboo/niri-flake) - A Nix flake for niri, providing a convenient way to install and manage niri on NixOS.
 
 ## Tools
-- [bar-rs](https://github.com/faervan/bar-rs) - A simple status bar, written using iced-rs.
-- [eww-niri-workspaces](https://github.com/druskus20/eww-niri-workspaces) - A rust binary that outputs workspace information from niri-ipc to be consumed by eww.
-- [Ignis](https://github.com/linkfrg/ignis) - A widget framework for building desktop shells, written and configurable in Python.
 - [niri-float-sticky](https://github.com/probeldev/niri-float-sticky) - A utility to make floating windows visible across all workspaces in niri — similar to "sticky windows" in other compositors.
 - [niri-screen-time](https://github.com/probeldev/niri-screen-time) - A utility that collects information about how much time you spend in each application.
 - [niri-scripts](https://github.com/0xwal/niri-scripts) - A collection of scripts to enhance the niri experience.
@@ -37,6 +34,11 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [Nirius](https://sr.ht/~tsdh/nirius) - Utility commands for the niri.
 - [nsticky](https://github.com/lonerOrz/nsticky) - A utility to make windows visible across all workspaces in niri.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.
+
+## Bars and widgets
+- [bar-rs](https://github.com/faervan/bar-rs) - A simple status bar, written using iced-rs.
+- [eww-niri-workspaces](https://github.com/druskus20/eww-niri-workspaces) - A rust binary that outputs workspace information from niri-ipc to be consumed by eww.
+- [Ignis](https://github.com/linkfrg/ignis) - A widget framework for building desktop shells, written and configurable in Python.
 
 ## Custom Shells
 - [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) - Quickshell based shell featuring Material 3 design principles, with a heavy focus on functionality and customizability.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [bar-rs](https://github.com/faervan/bar-rs) - A simple status bar, written using iced-rs.
 - [eww-niri-workspaces](https://github.com/druskus20/eww-niri-workspaces) - A rust binary that outputs workspace information from niri-ipc to be consumed by eww.
 - [Ignis](https://github.com/linkfrg/ignis) - A widget framework for building desktop shells, written and configurable in Python.
+- [Waybar](https://github.com/Alexays/Waybar) - Highly customizable Wayland bar based on gtk which supports showing information about workspaces, windows names and keyboard layout.
 
 ## Custom Shells
 - [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) - Quickshell based shell featuring Material 3 design principles, with a heavy focus on functionality and customizability.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [Official Resources](#official-resources)
 - [Packages](#packages)
 - [Tools](#tools)
-- [Bars and widgets](#bars-and-widgets)
+- [Bars and Widgets](#bars-and-widgets)
 - [Custom Shells](#custom-shells)
 - [DE Integration](#de-integration)
 - [Distro Integration](#distro-integration)
@@ -36,11 +36,11 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [nsticky](https://github.com/lonerOrz/nsticky) - A utility to make windows visible across all workspaces in niri.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.
 
-## Bars and widgets
+## Bars and Widgets
 - [bar-rs](https://github.com/faervan/bar-rs) - A simple status bar, written using iced-rs.
 - [eww-niri-workspaces](https://github.com/druskus20/eww-niri-workspaces) - A rust binary that outputs workspace information from niri-ipc to be consumed by eww.
 - [Ignis](https://github.com/linkfrg/ignis) - A widget framework for building desktop shells, written and configurable in Python.
-- [Waybar](https://github.com/Alexays/Waybar) - Highly customizable Wayland bar based on gtk.
+- [Waybar](https://github.com/Alexays/Waybar) - Highly customizable Wayland bar based on GTK.
 
 ## Custom Shells
 - [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) - Quickshell based shell featuring Material 3 design principles, with a heavy focus on functionality and customizability.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [bar-rs](https://github.com/faervan/bar-rs) - A simple status bar, written using iced-rs.
 - [eww-niri-workspaces](https://github.com/druskus20/eww-niri-workspaces) - A rust binary that outputs workspace information from niri-ipc to be consumed by eww.
 - [Ignis](https://github.com/linkfrg/ignis) - A widget framework for building desktop shells, written and configurable in Python.
-- [Waybar](https://github.com/Alexays/Waybar) - Highly customizable Wayland bar based on gtk which supports showing information about workspaces, windows names and keyboard layout.
+- [Waybar](https://github.com/Alexays/Waybar) - Highly customizable Wayland bar based on gtk.
 
 ## Custom Shells
 - [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) - Quickshell based shell featuring Material 3 design principles, with a heavy focus on functionality and customizability.


### PR DESCRIPTION
First of all, thank you for this project!

About the PR: in my opinion status bars and widgets should be placed in an appropriate category, distinct from the generic "Tools" section which may rapidly become extremely cluttered, especially if new projects come out and get added to the list. On this note, I'm going to make other PRs for adding to the list other status bars which support showing niri workspaces, and I believe a standalone section would be better suited for this.