### PR TITLE
Add niri tweaks to "Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [hyprlax](https://github.com/sandwichfarm/hyprlax) - Smooth parallax wallpaper daemon.
 - [IIO-Niri](https://github.com/Zhaith-Izaliel/iio-niri) - Listen to iio-sensor-proxy and update niri output orientation depending on the accelerometer orientation.
 - [nfsm](https://github.com/gvolpe/nfsm) - Fullscreen manager for niri.
-- [niri tweaks](https://github.com/heyoeyo/niri_tweaks) - A collection of scripts to modify niri's behavior.
 - [niri-companion](https://github.com/dybdeskarphet/niri-companion) - A toolkit that adds extra functionality to niri.
 - [niri-float-sticky](https://github.com/probeldev/niri-float-sticky) - A utility to make floating windows visible across all workspaces in niri — similar to "sticky windows" in other compositors.
 - [niri-scratchpad](https://github.com/gvolpe/niri-scratchpad) - Scratchpad support for niri.
@@ -55,6 +54,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 
 ## Scripts
 - [ndrop](https://github.com/Schweber/ndrop) - Emulate tdrop in niri.
+- [niri tweaks](https://github.com/heyoeyo/niri_tweaks) - A collection of scripts. Notably includes a script which allows tiling N windows before scrolling new ones.
 - [niri-scripts](https://github.com/0xwal/niri-scripts) - A collection of scripts. Notably allows setting wallpaper per workspace.
 
 ## Bars and Widgets


### PR DESCRIPTION
Notably, niri tweaks includes the "niri-tile-to-n" script, which let's you tile N windows before scrolling new ones. This might be worth mentioning in the description.