### PR TITLE
Add Okimarchy to Distro Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 
 ## Distro Integration
 - [CachyOS](https://wiki.cachyos.org/configuration/desktop_environments/niri) - CachyOS is a Arch Linux based distribution focused around gaming, performance, and being user-friendly. It provides niri as an install option via its installer.
-- [Okimarchy](https://github.com/cristian-fleischer/okimarchy) - An Omarchy fork that adds dual window manager support for niri alongside Hyprland (Omarchy default), with runtime switching capabilities and unified theming.
+- [Okimarchy](https://github.com/cristian-fleischer/okimarchy) - An Omarchy fork that adds support for niri alongside Hyprland, with runtime switching and unified theming.
 - [Pika OS](https://wiki.pika-os.com/en/home#niri-edition) - PikaOS is a Debian sid based Linux distribution focused on gaming and performance optimization, which provides a niri edition ISO.
 
 ## Rices


### PR DESCRIPTION
This PR adds Okimarchy to the Distro Integration section.

Okimarchy is an Omarchy fork that adds niri window manager support to Omarchy, with runtime switching capabilities, unified theming and configuration improvements.

Project link: https://github.com/cristian-fleischer/okimarchy