### PR TITLE
niri-scratchpad-rs entry add

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [niri-companion](https://github.com/dybdeskarphet/niri-companion) - A toolkit that adds extra functionality to niri.
 - [niri-float-sticky](https://github.com/probeldev/niri-float-sticky) - A utility to make floating windows visible across all workspaces in niri — similar to "sticky windows" in other compositors.
 - [niri-scratchpad](https://github.com/gvolpe/niri-scratchpad) - Scratchpad support for niri.
+- [niri-scratchpad-rs](https://github.com/argosnothing/niri-scratchpad-rs) - Dynamic scratchpads for niri.
 - [niri-screen-time](https://github.com/probeldev/niri-screen-time) - A utility that collects information about how much time you spend in each application.
 - [niri-session-manager](https://github.com/MTeaHead/niri-session-manager) - Automatically save and restore windows in the niri Wayland compositor.
 - [niri-settings](https://github.com/stefonarch/niri-settings) - Basic configuration GUI for niri.


### PR DESCRIPTION
This is an implementation I use for scratchpads. It's a little unique vs the other scratchpad implementations for a few reasons: 

### 1. Dynamic Scratchpads
`niri-scratchpad-rs` does not require you to configure based on window properties before hand. You instead bind the command against a *register* and on-the-fly assign windows against that register. This lets you actively manage scratchpad windows as you need them, instead of statically, based on your config. 

### 2. Compositor-based Ids
We use the `window-id` given be the focused window through the niri_ipc crate to tie a scratchpad register to a window. This allows us to only bind the physical window as recognized by the compositor internally. What this essentially means is that you do can have a single instance of an application be a scratchpad when you need it, without having to reserve by app_id or title to an entire class of windows.

### 3. Register Querying
`niri-scratchpad-rs` internally tracks windows it has assigned to each register, and you can additionally query it using the `get` action. Currently this works with both titles and app_ids. I have used this feature to make my own custom buttons in noctalia that update as I assign scratchpads to registers. 

https://github.com/argosnothing/niri-scratchpad-rs