### PR TITLE
Added shader-desk to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 - [Nirius](https://sr.ht/~tsdh/nirius) - Utility commands.
 - [nsticky](https://github.com/lonerOrz/nsticky) - A utility to make windows visible across all workspaces.
 - [pandora](https://github.com/PandorasFox/pandora) - Parallax-scrolling wallpaper daemon for Wayland.
+- [shader-desk](https://gitea.com/SeeTheWall/shader-desk) - Interactive wallpapers based on shaders for Wayland compositors. 
 - [Stasis](https://github.com/saltnpepper97/stasis) - A modern Wayland idle manager with smart timeouts, media awareness, and app-specific inhibition.
 - [swaytreesave](https://github.com/fabienjuif/swaytreesave) - CLI to save and load your compositors tree/layout.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.


### PR DESCRIPTION
Added shader-desk to the list of tools.  This is a project that allows you to develop and launch wallpapers using shaders in Wayland compositors. The project was developed in niri and for niri, but it aims to not be limited to one compositor.