### PR TITLE
Add niri-screensaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [kunai](https://github.com/mikkurogue/kunai) - Automatically switch keyboard layouts based on which physical keyboard is being used.
 - [NASW](https://github.com/ledati16/nasw) - Automatically switch audio based on active windows.
 - [niri-autoselect-portal](https://codeberg.org/debugloop/niri-autoselect-portal) - Always autoselect the dynamic cast target without any prompts.
+- [niri-screensaver](https://github.com/jfreed-dev/niri-screensaver) - Idle-aware terminal screensaver for niri, driven by TerminalTextEffects, with an optional Noctalia plugin for IdleService integration.
 - [nirilayout](https://github.com/calico32/nirilayout) - Quickly switch output configuration between different layouts.
 - [Stasis](https://github.com/saltnpepper97/stasis) - A modern Wayland idle manager with smart timeouts, media awareness, and app-specific inhibition.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.


### PR DESCRIPTION
Idle-aware terminal screensaver for niri, driven by TerminalTextEffects. Ships a small bash CLI plus a Noctalia plugin that wires IdleService → screensaver. GPL-3.0-only. https://github.com/jfreed-dev/niri-screensaver