### PR TITLE
Add npwskl

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [Stasis](https://github.com/saltnpepper97/stasis) - A modern Wayland idle manager with smart timeouts, media awareness, and app-specific inhibition.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.
+- [npwskl](https://github.com/danylo-volchenko/npwskl) - Per-workspace keyboard layout utility.
 
 ### Miscellaneous
 - [arbtt-capture-wl](https://github.com/franzos/arbtt-capture-wl) - Time tracker utility [arbtt](https://github.com/nomeata/arbtt) ported to Wayland.


### PR DESCRIPTION
NPWSKL - Niri Per-Workspace Keyboard Layout utility.
Remembers and auto-switches keyboard layout based on currently focused workspace.

### I'll just quote  README:

### What is it?
A Rust utility that maintains different keyboard layouts across workspaces.
It uses network-based IPC (branch with shell-based IPC interface is also available) to subscribe to the
Niri event-stream. This stream contains a current state of the workspaces, their indices, active layout, etc.
It parses set of events related to workspaces and keyboard layout into a state map, then, upon switching to
some workspace - restores it's last used keyboard layout (`niri msg switch-layout <idx>`).

### Use case
Multi-lingual setups. I was tired of switching between 3 layouts when coding and chatting with somebody.
Same functionality exists somewhere in the depths of GNOME compositor.