### PR TITLE
Add niriSKL.nvim to "System Integration and Automation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ For tools that integrate niri with other system components or automate tasks.
 - [kunai](https://github.com/mikkurogue/kunai) - Automatically switch keyboard layouts based on which physical keyboard is being used.
 - [NASW](https://github.com/ledati16/nasw) - Automatically switch audio based on active windows.
 - [niri-autoselect-portal](https://codeberg.org/debugloop/niri-autoselect-portal) - Always autoselect the dynamic cast target without any prompts.
-- [niri-screensaver](https://github.com/jfreed-dev/niri-screensaver) - Idle-aware terminal screensaver for niri, driven by TerminalTextEffects, with an optional Noctalia plugin for IdleService integration.
-- [niriSKL.nvim](https://github.com/MahouShoujoMivutilde/niriSKL.nvim) - A Neovim plugin that maintains your latin keyboard layout of choice for NORMAL mode and restores the layout you had when in INSERT mode.
 - [nirilayout](https://github.com/calico32/nirilayout) - Quickly switch output configuration between different layouts.
 - [nirimon](https://github.com/stepbrobd/nirimon) - A TUI monitor configuration tool with visual layout, drag-and-drop, and profile management (profile schema compliant with hyprmon).
+- [niri-screensaver](https://github.com/jfreed-dev/niri-screensaver) - Idle-aware terminal screensaver for niri, driven by TerminalTextEffects, with an optional Noctalia plugin for IdleService integration.
+- [niriSKL.nvim](https://github.com/MahouShoujoMivutilde/niriSKL.nvim) - A Neovim plugin that maintains your latin keyboard layout of choice for NORMAL mode and restores the layout you had when in INSERT mode.
 - [Stasis](https://github.com/saltnpepper97/stasis) - A modern Wayland idle manager with smart timeouts, media awareness, and app-specific inhibition.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [NASW](https://github.com/ledati16/nasw) - Automatically switch audio based on active windows.
 - [niri-autoselect-portal](https://codeberg.org/debugloop/niri-autoselect-portal) - Always autoselect the dynamic cast target without any prompts.
 - [niri-screensaver](https://github.com/jfreed-dev/niri-screensaver) - Idle-aware terminal screensaver for niri, driven by TerminalTextEffects, with an optional Noctalia plugin for IdleService integration.
+- [niriSKL.nvim](https://github.com/MahouShoujoMivutilde/niriSKL.nvim) - A Neovim plugin that maintains your latin keyboard layout of choice for NORMAL mode and restores the layout you had when in INSERT mode.
 - [nirilayout](https://github.com/calico32/nirilayout) - Quickly switch output configuration between different layouts.
 - [nirimon](https://github.com/stepbrobd/nirimon) - A TUI monitor configuration tool with visual layout, drag-and-drop, and profile management (profile schema compliant with hyprmon).
 - [Stasis](https://github.com/saltnpepper97/stasis) - A modern Wayland idle manager with smart timeouts, media awareness, and app-specific inhibition.

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ For tools that integrate niri with other system components or automate tasks.
 - [kunai](https://github.com/mikkurogue/kunai) - Automatically switch keyboard layouts based on which physical keyboard is being used.
 - [NASW](https://github.com/ledati16/nasw) - Automatically switch audio based on active windows.
 - [niri-autoselect-portal](https://codeberg.org/debugloop/niri-autoselect-portal) - Always autoselect the dynamic cast target without any prompts.
+- [niri-screensaver](https://github.com/jfreed-dev/niri-screensaver) - Idle-aware terminal screensaver for niri, driven by TerminalTextEffects, with an optional Noctalia plugin for IdleService integration.
 - [nirilayout](https://github.com/calico32/nirilayout) - Quickly switch output configuration between different layouts.
 - [nirimon](https://github.com/stepbrobd/nirimon) - A TUI monitor configuration tool with visual layout, drag-and-drop, and profile management (profile schema compliant with hyprmon).
-- [niri-screensaver](https://github.com/jfreed-dev/niri-screensaver) - Idle-aware terminal screensaver for niri, driven by TerminalTextEffects, with an optional Noctalia plugin for IdleService integration.
 - [niriSKL.nvim](https://github.com/MahouShoujoMivutilde/niriSKL.nvim) - A Neovim plugin that maintains your latin keyboard layout of choice for NORMAL mode and restores the layout you had when in INSERT mode.
 - [Stasis](https://github.com/saltnpepper97/stasis) - A modern Wayland idle manager with smart timeouts, media awareness, and app-specific inhibition.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.


### PR DESCRIPTION
**What is it**, to quote the readme:

[niriSKL.nvim](https://github.com/MahouShoujoMivutilde/niriSKL.nvim) ("smart keyboard layout") is a lua plugin for Neovim that switches niri keyboard layout ensuring that you'll have:
* your latin layout of choice - when in NORMAL mode
* whatever layout you were using for actually writing - when in INSERT mode

Inspired by [vim-xkbswitch](https://github.com/lyokha/vim-xkbswitch). But _a lot_ more minimal and niri specific.

**Why?**

`vim.o.langmap` **sucks**!

It has annoying edge cases where it fails, and if you add another layout to your compositor - congrats, now you need to write a new `langmap`!

It's much simpler to just switch to the correct layout in NORMAL mode, and restore whatever you were using in INSERT mode. And that's exactly what niriSKL does.
