### PR TITLE
Add niri-screenshot-tools to misc. tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ For tools that integrate niri with other system components or automate tasks.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.
 
-### Miscellaneous
+<!-- ### Miscellaneous -->
 - [arbtt-capture-wl](https://github.com/franzos/arbtt-capture-wl) - Time tracker utility [arbtt](https://github.com/nomeata/arbtt) ported to Wayland.
 - [niri-cwd](https://github.com/nouritsu/niri-cwd) - A program to print the focused window's working directory.
 - [niri-screen-time](https://github.com/probeldev/niri-screen-time) - A utility that collects information about how much time you spend in each application.
+- [niri-screenshot-tools](https://codeberg.org/whenthesilly/niri-screenshot-tools) - A program that sends screenshots taken in niri to an annotator or uploads them to a server
 - [niri-settings](https://github.com/stefonarch/niri-settings) - Basic configuration GUI for niri config.
 - [nirimod](https://github.com/srinivasr/nirimod) - A visual, interactive configuration interface.
-- [niri-screenshot-tools](https://codeberg.org/whenthesilly/niri-screenshot-tools) - A program that sends screenshots taken in niri to an annotator or uploads them to a server
 
 ## Custom Shaders
 - [Nirimation](https://github.com/XansiVA/nirimation) - A host for custom shaders to be used as animations.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [arbtt-capture-wl](https://github.com/franzos/arbtt-capture-wl) - Time tracker utility [arbtt](https://github.com/nomeata/arbtt) ported to Wayland.
 - [niri-cwd](https://github.com/nouritsu/niri-cwd) - A program to print the focused window's working directory.
 - [niri-screen-time](https://github.com/probeldev/niri-screen-time) - A utility that collects information about how much time you spend in each application.
-- [niri-screenshot-tools](https://codeberg.org/whenthesilly/niri-screenshot-tools) - A program that sends screenshots taken in niri to an annotator or uploads them to a server
+- [niri-screenshot-tools](https://codeberg.org/whenthesilly/niri-screenshot-tools) - A program that sends screenshots taken in niri to an annotator or uploads them to a server.
 - [niri-settings](https://github.com/stefonarch/niri-settings) - Basic configuration GUI for niri config.
 - [nirimod](https://github.com/srinivasr/nirimod) - A visual, interactive configuration interface.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [system76-scheduler-niri](https://github.com/Kirottu/system76-scheduler-niri) - A simple daemon to update the foreground process of [system76-scheduler](https://github.com/pop-os/system76-scheduler) based on the focused window.
 - [vim-niri-nav](https://github.com/andergrim/vim-niri-nav) - Seamless navigation between niri windows and (neo)vim splits with the same key bindings.
 
-<!-- ### Miscellaneous -->
+### Miscellaneous
 - [arbtt-capture-wl](https://github.com/franzos/arbtt-capture-wl) - Time tracker utility [arbtt](https://github.com/nomeata/arbtt) ported to Wayland.
 - [niri-cwd](https://github.com/nouritsu/niri-cwd) - A program to print the focused window's working directory.
 - [niri-screen-time](https://github.com/probeldev/niri-screen-time) - A utility that collects information about how much time you spend in each application.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [niri-screen-time](https://github.com/probeldev/niri-screen-time) - A utility that collects information about how much time you spend in each application.
 - [niri-settings](https://github.com/stefonarch/niri-settings) - Basic configuration GUI for niri config.
 - [nirimod](https://github.com/srinivasr/nirimod) - A visual, interactive configuration interface.
+- [niri-screenshot-tools](https://codeberg.org/whenthesilly/niri-screenshot-tools) - A program that sends screenshots taken in niri to an annotator or uploads them to a server
 
 ## Custom Shaders
 - [Nirimation](https://github.com/XansiVA/nirimation) - A host for custom shaders to be used as animations.


### PR DESCRIPTION
The main way to use a screenshot annotator is to pipe it from something like grim, but what if you want to use the built-in niri one with its better integration? This listens on the ipc and lets you do that. It also lets you upload your screenshots straight to a file server like copyparty, allowing for easier sharing