### PR TITLE
Add Glimpse to Custom Shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For tools that integrate niri with other system components or automate tasks.
 - [Delta Shell](https://github.com/Sinomor/delta-shell) - A desktop shell based on AGS with many features.
 - [desktop-shell](https://github.com/hashankur/desktop-shell) - Custom AGS shell for Wayland compositors supporting wayland-layer-shell.
 - [Exo](https://github.com/debuggyo/Exo) - A Material 3 inspired desktop shell created with Ignis.
+- [Glimpse](https://github.com/alex-oleshkevich/glimpse) - A niri-first Wayland desktop shell toolkit with a panel, wallpaper, lock screen, night light, and idle management.
 - [GPUi Shell](https://github.com/andre-brandao/gpui-shell) - A GPUI based shell written in Rust.
 - [IgnisNiriShell](https://github.com/lost-melody/IgnisNiriShell) - An Ignis based shell.
 - [iNiR](https://github.com/snowarch/iNiR) - [end-4's quickshell config](https://github.com/end-4/dots-hyprland) modified to work with niri.


### PR DESCRIPTION
Adds Glimpse to the Custom Shells section.

Glimpse is built specifically for niri and provides the surrounding desktop layer: a GTK4 panel, wallpaper and backdrop surfaces, a lock screen, night light, and idle management.

This makes the project discoverable alongside other niri-focused desktop shells.

Checks:

- `npx --yes awesome-lint README.md`
- `git diff --check upstream/main...HEAD`
