### PR TITLE
docs: update niri-flake to actively maintained epireyn fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ _Please read the [contributing guidelines](CONTRIBUTING.md) before contributing 
 
 ## Packages
 - [Community Packages](https://repology.org/project/niri/packages) - A list of community maintained packages for niri.
-- [niri-flake](https://github.com/sodiboo/niri-flake) - A Nix flake with cached binary builds and batteries-included modules[^1].
+- [niri-flake](https://github.com/epireyn/niri-flake) - A Nix flake with cached binary builds and batteries-included modules (actively maintained fork of [sodiboo/niri-flake](https://github.com/sodiboo/niri-flake)).
 - [niri-nix](https://codeberg.org/bananad3v/niri-nix) - A Nix flake with cached binary builds and freeform config.
-
-[^1]: The module has not been updated since the 25.08 release and hence is missing configuration for many new features added since then. It is suggested to use `niri-nix` instead which uses a freeform config.
 
 ## Tools
 


### PR DESCRIPTION
Update the `niri-flake` entry in Packages to point to `epireyn/niri-flake`, which actively maintains binary caches and updates features for current niri releases.